### PR TITLE
Preserve signup email formatting

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -140,7 +140,7 @@ def signup_for_activity(activity_name: str, email: str):
     if len(activity["participants"]) >= activity["max_participants"]:
         raise HTTPException(status_code=409, detail="Activity is full")
 
-    # Add student (preserve original formatting while preventing case-sensitive duplicates)
+    # Add student (preserve original formatting while preventing case-insensitive duplicates)
     activity["participants"].append(normalized)
     return {"message": f"Signed up {normalized} for {activity_name}"}
 


### PR DESCRIPTION
## Summary
- keep the stored participant email in its trimmed original form while still preventing case-insensitive duplicates
- document the intent in the signup handler comment

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910052d95e083238ac4046439925f61)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email addresses are now stored with their original formatting when signing up for activities, while duplicate detection remains case-insensitive and messages reflect the provided email.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->