### PR TITLE
Add activity availability endpoint

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -145,6 +145,28 @@ def signup_for_activity(activity_name: str, email: str):
     return {"message": f"Signed up {normalized} for {activity_name}"}
 
 
+def _availability_for(activity_name: str) -> dict:
+    """Return availability details for a given activity."""
+    activity = activities[activity_name]
+    total_slots = activity["max_participants"]
+    taken_slots = len(activity["participants"])
+    return {
+        "activity_name": activity_name,
+        "total_slots": total_slots,
+        "taken_slots": taken_slots,
+        "available_slots": max(total_slots - taken_slots, 0),
+    }
+
+
+@app.get("/activities/{activity_name}/availability")
+def get_activity_availability(activity_name: str):
+    """Return capacity information for a single activity."""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    return _availability_for(activity_name)
+
+
 # ============================================================================
 # AI-Powered Endpoints (require ANTHROPIC_API_KEY environment variable)
 # ============================================================================

--- a/tests/test_app_baseline.py
+++ b/tests/test_app_baseline.py
@@ -35,3 +35,21 @@ def test_ai_status_endpoint_reports_disabled_when_no_key():
     payload = resp.json()
     assert payload["ai_enabled"] is False
     assert "Set ANTHROPIC_API_KEY" in payload["message"]
+
+
+def test_get_activity_availability():
+    resp = client.get("/activities/Chess Club/availability")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload == {
+        "activity_name": "Chess Club",
+        "total_slots": 12,
+        "taken_slots": 2,
+        "available_slots": 10,
+    }
+
+
+def test_get_activity_availability_missing():
+    resp = client.get("/activities/Unknown Club/availability")
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Activity not found"}


### PR DESCRIPTION
## Summary
- add a helper to calculate availability information for activities
- expose a new `/activities/{activity_name}/availability` endpoint with capacity data
- cover the new endpoint with tests for success and missing activities

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691011fbf86c8323859108117f00c782)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added availability information for activities, displaying total slots, how many are taken, and how many remain available.

* **Tests**
  * Added tests to verify availability data retrieval and proper error handling when activities don't exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->